### PR TITLE
1.8.6-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 Release v1.8.6 (dev) :
 - Bug corrections :
+  - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
+  - Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.
 
 Release v1.8.5 (beta) :
 - Nouveautés :

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.6 (dev) :
+Release v1.8.6 (beta) :
 - Bug corrections :
   - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
   - Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.6 (dev) :
+- Bug corrections :
+
 Release v1.8.5 (beta) :
 - Nouveautés :
   - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1418,6 +1418,13 @@ class centralepilote extends eqLogic {
       // ----- Look for existing device
       else {
         centralepilotelog::log('debug', "preSaveRadiateur() : existing radiateur.");
+        
+        // ----- Verification de certains paramètres avant sauvegarde
+        $v_nature = $this->getConfiguration('nature_fil_pilote','');
+        $v_fp_device_id = $this->getConfiguration('fp_device_id','');
+        if (($v_nature == 'fp_device') && ($v_fp_device_id == '')) {
+          throw new Exception(__("Il manque l'identifiant de l'objet fil-pilote.", __FILE__));
+        }        
 
         // ----- Load device (eqLogic) from DB
         // These values will be erased with the save in DB, so keep what is needed to be kept
@@ -1456,7 +1463,8 @@ class centralepilote extends eqLogic {
       }
       centralepilotelog::log('debug', "preSaveRadiateur() done");
     }
-
+    
+    
     public function preSaveZone() {
       //centralepilotelog::log('debug', "preSave()");
       

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -119,6 +119,7 @@
         "Mode Confort -2 :" : "Confort -2 mode :",
         "Mode Eco :" : "Eco mode :",
         "Mode Hors-Gel :" : "Hors-Gel mode :",
+        "Changer équipement" : "Change device",
 
         "#": "#"
     },
@@ -274,6 +275,7 @@
         "Retour" : "Return",
         "Valider" : "Confirm",
         "à" : "at",
+        "Il manque l'identifiant de l'objet fil-pilote." : "Missing fil-pilote object id.",
 
         "#": "#"
     }

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.6-dev');
+  define('CP_VERSION', '1.8.6-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.5');
+  define('CP_VERSION', '1.8.6-dev');
 
 
 ?>

--- a/desktop/js/centralepilote.js
+++ b/desktop/js/centralepilote.js
@@ -508,16 +508,19 @@ function cp_nature_change(event) {
   }
   
   else if (event.target.value == 'fp_device') {
-    // ----- Mise à jour de la liste des eq fil-pilote compatibles
-    cp_fp_update_list();
-    
     // ----- Afficher le div
     $('#cp_disp_fp_device').show();
+    
+    /*
+    if ($('#cp_fp_device_selected').val() == '') {
+      cp_fp_device_list_open();
+    }
+    */
   }
   
 }
 
-function cp_fp_update_list() {
+function cp_fp_update_list_DEPRECATED(p_id='') {
 
   $.ajax({
     type: "POST",
@@ -539,7 +542,57 @@ function cp_fp_update_list() {
       
       var v_html = '';
       for (var i in v_data) {
-        v_html += '<option value="#'+v_data[i]['human_name']+'#">'+v_data[i]['human_name']+'</option>';
+        var v_item = "#"+v_data[i]['human_name']+"#";
+        if (v_item == p_id) {
+          v_html += '<option value="'+v_item+'" selected>'+v_item+'</option>';
+        }
+        else {
+          v_html += '<option value="'+v_item+'">'+v_item+'</option>';
+        }
+      }
+    
+      $('#cp_fp_device_list').html(v_html);
+
+    }
+  });
+  
+}
+
+function cp_fp_device_list_open(p_id='') {
+
+  $('#cp_fp_device_selected').hide();
+  $('#cp_fp_device_list_open_span').hide();
+
+  $('#cp_fp_device_list').show();
+  $('#cp_fp_device_select_span').show();
+  
+  $.ajax({
+    type: "POST",
+    url: "plugins/centralepilote/core/ajax/centralepilote.ajax.php",
+    data: {
+      action: "cpFpSupportedList"
+    },
+    dataType: 'json',
+    error: function (request, status, error) {
+      handleAjaxError(request, status, error);
+    },
+    success: function (data) {
+      if (data.state != 'ok') {
+        $('#div_alert').showAlert({message: data.result, level: 'danger'});
+        return;
+      }
+      v_val = data.result;
+      v_data = JSON.parse(v_val);
+      
+      var v_html = '';
+      for (var i in v_data) {
+        var v_item = "#"+v_data[i]['human_name']+"#";
+        if (v_item == p_id) {
+          v_html += '<option value="'+v_item+'" selected>'+v_item+'</option>';
+        }
+        else {
+          v_html += '<option value="'+v_item+'">'+v_item+'</option>';
+        }
       }
     
       $('#cp_fp_device_list').html(v_html);
@@ -551,7 +604,32 @@ function cp_fp_update_list() {
 
 
 function cp_fp_device_change(event) {
-  //alert('Hello :'+event.target.value);
+  //alert('target :'+event.target.value);
+  //$('#cp_fp_device_selected').val(event.target.value);
+  
+  
+}
+
+function cp_fp_device_select(p_value) {
+  //alert('target :'+event.target.value);
+  $('#cp_fp_device_selected').val(p_value);
+  
+  $('#cp_fp_device_selected').show();
+  $('#cp_fp_device_list_open_span').show();
+
+  $('#cp_fp_device_list').hide();
+  $('#cp_fp_device_select_span').hide();
+ 
+}
+
+function cp_fp_device_cancel_select() {
+  
+  $('#cp_fp_device_selected').show();
+  $('#cp_fp_device_list_open_span').show();
+
+  $('#cp_fp_device_list').hide();
+  $('#cp_fp_device_select_span').hide();
+ 
 }
 
 

--- a/desktop/js/centralepilote.js
+++ b/desktop/js/centralepilote.js
@@ -60,6 +60,7 @@ function addCmdToTable(_cmd) {
 var refresh_timeout;
 
 function refreshDeviceList() {
+  //console.log('refresh device list');
   $('#device_list').load('index.php?v=d&plugin=centralepilote&modal=modal.device_list');
 }
 
@@ -596,6 +597,9 @@ function cp_fp_device_list_open(p_id='') {
       }
     
       $('#cp_fp_device_list').html(v_html);
+      
+      // ----- Copie de suite celui affiché dans la selection
+      $('#cp_fp_device_selected').val($('#cp_fp_device_list').val());
 
     }
   });
@@ -606,6 +610,8 @@ function cp_fp_device_list_open(p_id='') {
 function cp_fp_device_change(event) {
   //alert('target :'+event.target.value);
   //$('#cp_fp_device_selected').val(event.target.value);
+  
+  cp_fp_device_select(event.target.value);
   
   
 }
@@ -631,7 +637,6 @@ function cp_fp_device_cancel_select() {
   $('#cp_fp_device_select_span').hide();
  
 }
-
 
 
 

--- a/desktop/php/centralepilote.php
+++ b/desktop/php/centralepilote.php
@@ -17,6 +17,9 @@ $eqLogics = eqLogic::byType($plugin->getId());
   $(document).ready(function() {
     // do this stuff when the HTML is all ready
     refreshDeviceList();
+       
+    
+    
   });
 
 </script>
@@ -111,7 +114,7 @@ Bon mais c'est juste pour que ce soit joli à l'affichage ...
 			</span>
 		</div>
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fa fa-arrow-circle-left"></i></a></li>
+    <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay" onClick="refreshDeviceList();"><i class="fa fa-arrow-circle-left"></i></a></li>
     <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
     <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fa fa-list-alt"></i> {{Commandes}}</a></li>
   </ul>

--- a/desktop/php/centralepilote_radiateur.inc.php
+++ b/desktop/php/centralepilote_radiateur.inc.php
@@ -60,38 +60,21 @@
       </label>
     <div class="col-sm-7">
 
-      <select id="cp_fp_device_list" class="cp_attr_radiateur eqLogicAttr form-control" data-l1key="configuration" data-l2key="fp_device_id" onchange="cp_fp_device_change(event)">
-        
-<?php 
-  // ----- Remplacé par un call uniquement lors de l'affichage voir cp_fp_update_list()
-  /*
-  $v_device_info_list = centralepilote::cpDeviceSupportedList();  
-  
-  $v_plugin_list = plugin::listPlugin(true);
-  foreach ($v_plugin_list as $v_plugin) {
-  	$v_plugin_id = $v_plugin->getId();
-  	if (!isset($v_device_info_list[$v_plugin_id])) continue;
-        
-    $eqLogics = eqLogic::byType($v_plugin_id);
-    foreach ($eqLogics as $v_eq) {
-      $v_device_info = centralepilote::cpDeviceSupportedInfo($v_eq);
-      if ($v_device_info != null) {
-        $v_human_name = $v_eq->getHumanName();
-        //$v_name = (isset($v_device_info['name'])?' ('.$v_device_info['name'].')':'');
-        
-        //echo '<option value="#'.$v_human_name.'#">'.$v_human_name.$v_name.'</option>';
-        echo '<option value="#'.$v_human_name.'#">'.$v_human_name.'</option>';
-      }
-    }
-  }
-  */
-  
-?>
-
+      <textarea id="cp_fp_device_selected" class="cp_attr_radiateur eqLogicAttr form-control" data-l1key="configuration" data-l2key="fp_device_id" style="height : 33px;" placeholder="{{Référence équipement associé}}"></textarea>
+      <select id="cp_fp_device_list" class="cp_attr_radiateur  form-control" onchange="cp_fp_device_change(event)" style="display:none;">
+        <!-- Rempli par javascript -->
       </select>
+
 
     </div>
     <div class="col-sm-1">
+      <span id="cp_fp_device_list_open_span">
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_list_open( $('#cp_fp_device_selected').val() );"><i class="fas fa-sync"></i> {{Changer équipement}}</a>
+      </span>
+      <span id="cp_fp_device_select_span" style="display:none; white-space: nowrap;">
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_select( $('#cp_fp_device_list').val() );" ><i class="fas fa-check" ></i>&nbsp;{{Valider}}</a>
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_cancel_select( );"><i class="fas fa-ban" ></i>&nbsp;{{Annuler}}</a>
+      </span>
     </div>
   </div>
 

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.6-dev",
+    "version": "1.8.6-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.5",
+    "version": "1.8.6-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,


### PR DESCRIPTION
Bug corrections :

- Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
- Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.