### PR TITLE
1.8.7-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 ### Change Logs
 
 Release v1.8.7 (dev) :
+- Nouveautés :
+  - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
 
 Release v1.8.6 (beta) :
 - Bug corrections :

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.7 (dev) :
+Release v1.8.7 (beta) :
 - Nouveautés :
   - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.7 (dev) :
+
 Release v1.8.6 (beta) :
 - Bug corrections :
   - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1986,9 +1986,18 @@ class centralepilote extends eqLogic {
       $replace['#cmd_eco_style#'] = '';
       $replace['#cmd_horsgel_style#'] = '';
       $replace['#cmd_off_style#'] = '';
-      $replace['#cmd_auto_style#'] = '';
-
-      $replace['#cmd_auto_style#'] = '';
+      
+      
+      // ----- Affichage des couleurs des icones en fonction de la config
+      if (config::byKey('mode_icon_color', 'centralepilote') == 1) {
+        $replace['#cmd_confort_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort').';';
+        $replace['#cmd_confort_1_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_1').';';
+        $replace['#cmd_confort_2_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_2').';';
+        $replace['#cmd_eco_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('eco').';';
+        $replace['#cmd_horsgel_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('horsgel').';';
+        $replace['#cmd_off_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('off').';';
+      }
+      
       $replace['#cmd_auto_style#'] = '';
       
       $v_cmd = $this->getCmd(null, 'pilotage');

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -219,6 +219,7 @@
         "Icones et Couleurs" : "Icons and Colors",
         "Widgets par d&eacute;faut : " : "Use default widgets : ",
         "Github Version" : "Github Version",
+        "Icônes des modes colorées" : "Colored icons for modes",
 
         "#": "#"
     },

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.7-dev');
+  define('CP_VERSION', '1.8.7-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.6-beta');
+  define('CP_VERSION', '1.8.7-dev');
 
 
 ?>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -36,6 +36,12 @@ if (!isConnect()) {
             </div>
         </div>
         <div class="row form-group">
+            <label class="col-lg-4 control-label">{{Icônes des modes colorées}} : </label>
+            <div class="col-lg-5">
+                <input type="checkbox" class="configKey form-control" data-l1key="mode_icon_color">
+            </div>
+        </div>
+        <div class="row form-group">
             <label class="col-lg-4 control-label">{{Github Version}} : <?php echo CP_VERSION;?></label>
         </div>
 

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.7-dev",
+    "version": "1.8.7-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.6-beta",
+    "version": "1.8.7-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,


### PR DESCRIPTION
Nouveautés :

- Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.