### PR TITLE
v1.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,26 +225,16 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.9 (beta) :
+Release v1.8.9 :
 - Nouveautés :
+  - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 
+  - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
   - Ajouté la possibilité de selectionner l'affichage de la couleur des icones de mode pour le tableau de bord et/ou pour le mobile.
   
-Release v1.8.8 (beta) :
-- Bug corrections :
-  - Ajout de l'affichage en couleur aussi pour le mode mobile
-  
-Release v1.8.7 (beta) :
-- Nouveautés :
-  - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
-
-Release v1.8.6 (beta) :
 - Bug corrections :
   - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
   - Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.
-
-Release v1.8.5 (beta) :
-- Nouveautés :
-  - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 
+  - Ajout de l'affichage en couleur aussi pour le mode mobile
 
 Release v1.8.4 :
 - Nouveautés :

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 ### Change Logs
 
 Release v1.8.7 (dev) :
+- Nouveautés :
+  - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
 
 Release v1.8.6 (beta) :
 - Bug corrections :

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 Release v1.8.6 (dev) :
 - Bug corrections :
+  - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
+  - Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.
 
 Release v1.8.5 (beta) :
 - Nouveautés :

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.8 (dev) :
+
 Release v1.8.7 (beta) :
 - Nouveautés :
   - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.9 (dev) :
+
 Release v1.8.8 (beta) :
 - Bug corrections :
   - Ajout de l'affichage en couleur aussi pour le mode mobile

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.5 (dev) :
+Release v1.8.5 (beta) :
 - Nouveautés :
   - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.6 (dev) :
+Release v1.8.6 (beta) :
 - Bug corrections :
   - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
   - Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.7 (dev) :
+Release v1.8.7 (beta) :
 - Nouveautés :
   - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.5 (dev) :
+
 Release v1.8.4 :
 - Nouveautés :
   - Ajout d'un bouton dans le widget d'un radiateur pour pouvoir directement accéder au dialogue de configuration des programmations sans avoir à aller dans la configuration du plugin.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.9 (dev) :
+Release v1.8.9 (beta) :
 - Nouveautés :
   - Ajouté la possibilité de selectionner l'affichage de la couleur des icones de mode pour le tableau de bord et/ou pour le mobile.
   

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.7 (dev) :
+
 Release v1.8.6 (beta) :
 - Bug corrections :
   - Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.

--- a/README.md
+++ b/README.md
@@ -225,8 +225,10 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
-Release v1.8.8 (dev) :
-
+Release v1.8.8 (beta) :
+- Bug corrections :
+  - Ajout de l'affichage en couleur aussi pour le mode mobile
+  
 Release v1.8.7 (beta) :
 - Nouveautés :
   - Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 ### Change Logs
 
 Release v1.8.9 (dev) :
-
+- Nouveautés :
+  - Ajouté la possibilité de selectionner l'affichage de la couleur des icones de mode pour le tableau de bord et/ou pour le mobile.
+  
 Release v1.8.8 (beta) :
 - Bug corrections :
   - Ajout de l'affichage en couleur aussi pour le mode mobile

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 
 ### Change Logs
 
+Release v1.8.6 (dev) :
+- Bug corrections :
+
 Release v1.8.5 (beta) :
 - Nouveautés :
   - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ De plus, à partir du moment où le délestage n'est plus actif, il est possible
 ### Change Logs
 
 Release v1.8.5 (dev) :
+- Nouveautés :
+  - Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote" 
 
 Release v1.8.4 :
 - Nouveautés :

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1330,6 +1330,19 @@ class centralepilote extends eqLogic {
         
         $this->cpCmdCreate('etat', ['name'=>'Etat', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>1, 'isVisible'=>1, 'order'=>$v_cmd_order++]);
         
+        // ----- Creation de commandes infos, contenant les valeurs configurées pour les températures de références
+        $this->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+
+        $this->checkAndUpdateCmd('temp_ref_confort', '19');
+        $this->checkAndUpdateCmd('temperature_confort_1', '18');
+        $this->checkAndUpdateCmd('temperature_confort_2', '17');
+        $this->checkAndUpdateCmd('temperature_eco', '15');
+        $this->checkAndUpdateCmd('temperature_horsgel', '3');
+        
         // ----- Here I can change the value because the centrale eq is created in "enable" status.
         $this->checkAndUpdateCmd('etat', 'normal');
       }
@@ -1776,7 +1789,12 @@ class centralepilote extends eqLogic {
             //$this->save();        
           }
         }
-  
+        
+        $this->checkAndUpdateCmd('temp_ref_confort', $this->getConfiguration('temperature_confort','19'));
+        $this->checkAndUpdateCmd('temp_ref_confort_1', $this->getConfiguration('temperature_confort_1','18'));
+        $this->checkAndUpdateCmd('temp_ref_confort_2', $this->getConfiguration('temperature_confort_2','17'));
+        $this->checkAndUpdateCmd('temp_ref_eco', $this->getConfiguration('temperature_eco','15'));
+        $this->checkAndUpdateCmd('temp_ref_horsgel', $this->getConfiguration('temperature_horsgel','3'));  
       }
       
       centralepilotelog::log('debug', "postSaveCentrale() : end");

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1989,7 +1989,8 @@ class centralepilote extends eqLogic {
       
       
       // ----- Affichage des couleurs des icones en fonction de la config
-      if (config::byKey('mode_icon_color', 'centralepilote') == 1) {
+      if ( (($_version == 'dashboard') && (config::byKey('mode_icon_color', 'centralepilote') == 1))
+           || (($_version == 'mobile') && (config::byKey('mode_icon_color_mobile', 'centralepilote') == 1)) ) {
         $replace['#cmd_confort_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort').';';
         $replace['#cmd_confort_1_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_1').';';
         $replace['#cmd_confort_2_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_2').';';

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1418,6 +1418,13 @@ class centralepilote extends eqLogic {
       // ----- Look for existing device
       else {
         centralepilotelog::log('debug', "preSaveRadiateur() : existing radiateur.");
+        
+        // ----- Verification de certains paramètres avant sauvegarde
+        $v_nature = $this->getConfiguration('nature_fil_pilote','');
+        $v_fp_device_id = $this->getConfiguration('fp_device_id','');
+        if (($v_nature == 'fp_device') && ($v_fp_device_id == '')) {
+          throw new Exception(__("Il manque l'identifiant de l'objet fil-pilote.", __FILE__));
+        }        
 
         // ----- Load device (eqLogic) from DB
         // These values will be erased with the save in DB, so keep what is needed to be kept
@@ -1456,7 +1463,8 @@ class centralepilote extends eqLogic {
       }
       centralepilotelog::log('debug', "preSaveRadiateur() done");
     }
-
+    
+    
     public function preSaveZone() {
       //centralepilotelog::log('debug', "preSave()");
       

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1986,9 +1986,18 @@ class centralepilote extends eqLogic {
       $replace['#cmd_eco_style#'] = '';
       $replace['#cmd_horsgel_style#'] = '';
       $replace['#cmd_off_style#'] = '';
-      $replace['#cmd_auto_style#'] = '';
-
-      $replace['#cmd_auto_style#'] = '';
+      
+      
+      // ----- Affichage des couleurs des icones en fonction de la config
+      if (config::byKey('mode_icon_color', 'centralepilote') == 1) {
+        $replace['#cmd_confort_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort').';';
+        $replace['#cmd_confort_1_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_1').';';
+        $replace['#cmd_confort_2_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('confort_2').';';
+        $replace['#cmd_eco_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('eco').';';
+        $replace['#cmd_horsgel_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('horsgel').';';
+        $replace['#cmd_off_icon_style#'] = 'color:'.centralepilote::cpModeGetColor('off').';';
+      }
+      
       $replace['#cmd_auto_style#'] = '';
       
       $v_cmd = $this->getCmd(null, 'pilotage');

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -2217,6 +2217,8 @@ class centralepilote extends eqLogic {
      * ---------------------------------------------------------------------------
      */
      // TBC : voir s'il faut garder cela .... pas utilisé
+     // En fait on utilise la même fonction mais un fichier html différent
+     // donc cela donne un résultat différent
     public function toHtml_mobile_radiateur($_version = 'mobile') {
       //centralepilote::log('debug',  "Call toHtml_mobile_radiateur()");
 

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1385,7 +1385,7 @@ class centralepilote extends eqLogic {
         $this->setConfiguration('support_eco', '1');
         $this->setConfiguration('support_horsgel', '1');
         $this->setConfiguration('support_off', '1');        
-        $this->setConfiguration('nature_fil_pilote', '2_commutateur');        
+        $this->setConfiguration('nature_fil_pilote', 'virtuel');        
         
         $this->setConfiguration('pilotage', 'eco');
         $this->setConfiguration('programme_id', '0');

--- a/core/class/centralepilote.class.php
+++ b/core/class/centralepilote.class.php
@@ -1331,17 +1331,17 @@ class centralepilote extends eqLogic {
         $this->cpCmdCreate('etat', ['name'=>'Etat', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>1, 'isVisible'=>1, 'order'=>$v_cmd_order++]);
         
         // ----- Creation de commandes infos, contenant les valeurs configurées pour les températures de références
-        $this->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
-        $this->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
-        $this->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
-        $this->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
-        $this->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
+        $this->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0, 'order'=>$v_cmd_order++]);
 
-        $this->checkAndUpdateCmd('temp_ref_confort', '19');
-        $this->checkAndUpdateCmd('temperature_confort_1', '18');
-        $this->checkAndUpdateCmd('temperature_confort_2', '17');
-        $this->checkAndUpdateCmd('temperature_eco', '15');
-        $this->checkAndUpdateCmd('temperature_horsgel', '3');
+        $this->checkAndUpdateCmd('temp_ref_confort', 19);
+        $this->checkAndUpdateCmd('temperature_confort_1', 18);
+        $this->checkAndUpdateCmd('temperature_confort_2', 17);
+        $this->checkAndUpdateCmd('temperature_eco', 15);
+        $this->checkAndUpdateCmd('temperature_horsgel', 3);
         
         // ----- Here I can change the value because the centrale eq is created in "enable" status.
         $this->checkAndUpdateCmd('etat', 'normal');
@@ -1790,11 +1790,11 @@ class centralepilote extends eqLogic {
           }
         }
         
-        $this->checkAndUpdateCmd('temp_ref_confort', $this->getConfiguration('temperature_confort','19'));
-        $this->checkAndUpdateCmd('temp_ref_confort_1', $this->getConfiguration('temperature_confort_1','18'));
-        $this->checkAndUpdateCmd('temp_ref_confort_2', $this->getConfiguration('temperature_confort_2','17'));
-        $this->checkAndUpdateCmd('temp_ref_eco', $this->getConfiguration('temperature_eco','15'));
-        $this->checkAndUpdateCmd('temp_ref_horsgel', $this->getConfiguration('temperature_horsgel','3'));  
+        $this->checkAndUpdateCmd('temp_ref_confort', intval($this->getConfiguration('temperature_confort','19')));
+        $this->checkAndUpdateCmd('temp_ref_confort_1', intval($this->getConfiguration('temperature_confort_1','18')));
+        $this->checkAndUpdateCmd('temp_ref_confort_2', intval($this->getConfiguration('temperature_confort_2','17')));
+        $this->checkAndUpdateCmd('temp_ref_eco', intval($this->getConfiguration('temperature_eco','15')));
+        $this->checkAndUpdateCmd('temp_ref_horsgel', intval($this->getConfiguration('temperature_horsgel','3')));  
       }
       
       centralepilotelog::log('debug', "postSaveCentrale() : end");

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -219,7 +219,9 @@
         "Icones et Couleurs" : "Icons and Colors",
         "Widgets par d&eacute;faut : " : "Use default widgets : ",
         "Github Version" : "Github Version",
-        "Icônes des modes colorées" : "Colored icons for modes",
+        "Icônes colorées pour les modes" : "Colored icons for modes",
+        "Tableau de bord" : "Dashboard",
+        "Mobile" : "Mobile",
 
         "#": "#"
     },

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -219,6 +219,7 @@
         "Icones et Couleurs" : "Icons and Colors",
         "Widgets par d&eacute;faut : " : "Use default widgets : ",
         "Github Version" : "Github Version",
+        "Icônes des modes colorées" : "Colored icons for modes",
 
         "#": "#"
     },

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -119,6 +119,7 @@
         "Mode Confort -2 :" : "Confort -2 mode :",
         "Mode Eco :" : "Eco mode :",
         "Mode Hors-Gel :" : "Hors-Gel mode :",
+        "Changer équipement" : "Change device",
 
         "#": "#"
     },
@@ -274,6 +275,7 @@
         "Retour" : "Return",
         "Valider" : "Confirm",
         "à" : "at",
+        "Il manque l'identifiant de l'objet fil-pilote." : "Missing fil-pilote object id.",
 
         "#": "#"
     }

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.7-dev');
+  define('CP_VERSION', '1.8.7-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.7-beta');
+  define('CP_VERSION', '1.8.8-dev');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.8-beta');
+  define('CP_VERSION', '1.8.9-dev');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.4');
+  define('CP_VERSION', '1.8.5');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.6-beta');
+  define('CP_VERSION', '1.8.7-dev');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.9-beta');
+  define('CP_VERSION', '1.8.9');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.9-dev');
+  define('CP_VERSION', '1.8.9-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.6-dev');
+  define('CP_VERSION', '1.8.6-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.8-dev');
+  define('CP_VERSION', '1.8.8-beta');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.5');
+  define('CP_VERSION', '1.8.6-dev');
 
 
 ?>

--- a/core/php/centralepilote_const.inc.php
+++ b/core/php/centralepilote_const.inc.php
@@ -17,7 +17,7 @@
 */
 
   // ----- Current version
-  define('CP_VERSION', '1.8.5');
+  define('CP_VERSION', '1.8.4');
 
 
 ?>

--- a/core/template/mobile/centralepilote-radiateur.template.html
+++ b/core/template/mobile/centralepilote-radiateur.template.html
@@ -26,12 +26,12 @@
     
     <div class="row cp_pilotage_buttons">
       <div class="col-sm-12 " style="margin: auto;">
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_show#" data-cmd_id="#cmd_confort_id#" style="font-size:22px; #cmd_confort_style#" >&nbsp;<i class="#cmd_confort_icon#"></i>&nbsp;</a>
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_1_show#" data-cmd_id="#cmd_confort_1_id#" style="font-size:22px; #cmd_confort_1_style#" >&nbsp;<i class="#cmd_confort_1_icon#"></i>&nbsp;</a>
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_2_show#" data-cmd_id="#cmd_confort_2_id#" style="font-size:22px; #cmd_confort_2_style#" >&nbsp;<i class="#cmd_confort_2_icon#"></i>&nbsp;</a>
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_eco_show#" data-cmd_id="#cmd_eco_id#" style="font-size:22px; #cmd_eco_style#" >&nbsp;<i class="#cmd_eco_icon#"></i>&nbsp;</a>
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_horsgel_show#" data-cmd_id="#cmd_horsgel_id#" style="font-size:22px; #cmd_horsgel_style#" >&nbsp;<i class="#cmd_horsgel_icon#"></i>&nbsp;</a>
-        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_off_show#" data-cmd_id="#cmd_off_id#" style="font-size:22px; #cmd_off_style#" >&nbsp;<i class="#cmd_off_icon#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_show#" data-cmd_id="#cmd_confort_id#" style="font-size:22px; #cmd_confort_style#" >&nbsp;<i class="#cmd_confort_icon#" style="#cmd_confort_icon_style#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_1_show#" data-cmd_id="#cmd_confort_1_id#" style="font-size:22px; #cmd_confort_1_style#" >&nbsp;<i class="#cmd_confort_1_icon#" style="#cmd_confort_1_icon_style#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_confort_2_show#" data-cmd_id="#cmd_confort_2_id#" style="font-size:22px; #cmd_confort_2_style#" >&nbsp;<i class="#cmd_confort_2_icon#" style="#cmd_confort_2_icon_style#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_eco_show#" data-cmd_id="#cmd_eco_id#" style="font-size:22px; #cmd_eco_style#" >&nbsp;<i class="#cmd_eco_icon#" style="#cmd_eco_icon_style#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_horsgel_show#" data-cmd_id="#cmd_horsgel_id#" style="font-size:22px; #cmd_horsgel_style#" >&nbsp;<i class="#cmd_horsgel_icon#" style="#cmd_horsgel_icon_style#"></i>&nbsp;</a>
+        <a class="btn btn-sm btn-default cmd tooltips cp_mode_button_#cmd_off_show#" data-cmd_id="#cmd_off_id#" style="font-size:22px; #cmd_off_style#" >&nbsp;<i class="#cmd_off_icon#" style="#cmd_off_icon_style#"></i>&nbsp;</a>
         <a class="btn btn-sm btn-default cmd tooltips" data-cmd_id="#cmd_auto_id#" style="font-size:22px; #cmd_auto_style#" >&nbsp;<i class="#cmd_auto_icon#"></i>&nbsp;</a>
       </div>
     </div>

--- a/desktop/js/centralepilote.js
+++ b/desktop/js/centralepilote.js
@@ -508,16 +508,19 @@ function cp_nature_change(event) {
   }
   
   else if (event.target.value == 'fp_device') {
-    // ----- Mise à jour de la liste des eq fil-pilote compatibles
-    cp_fp_update_list();
-    
     // ----- Afficher le div
     $('#cp_disp_fp_device').show();
+    
+    /*
+    if ($('#cp_fp_device_selected').val() == '') {
+      cp_fp_device_list_open();
+    }
+    */
   }
   
 }
 
-function cp_fp_update_list() {
+function cp_fp_update_list_DEPRECATED(p_id='') {
 
   $.ajax({
     type: "POST",
@@ -539,7 +542,57 @@ function cp_fp_update_list() {
       
       var v_html = '';
       for (var i in v_data) {
-        v_html += '<option value="#'+v_data[i]['human_name']+'#">'+v_data[i]['human_name']+'</option>';
+        var v_item = "#"+v_data[i]['human_name']+"#";
+        if (v_item == p_id) {
+          v_html += '<option value="'+v_item+'" selected>'+v_item+'</option>';
+        }
+        else {
+          v_html += '<option value="'+v_item+'">'+v_item+'</option>';
+        }
+      }
+    
+      $('#cp_fp_device_list').html(v_html);
+
+    }
+  });
+  
+}
+
+function cp_fp_device_list_open(p_id='') {
+
+  $('#cp_fp_device_selected').hide();
+  $('#cp_fp_device_list_open_span').hide();
+
+  $('#cp_fp_device_list').show();
+  $('#cp_fp_device_select_span').show();
+  
+  $.ajax({
+    type: "POST",
+    url: "plugins/centralepilote/core/ajax/centralepilote.ajax.php",
+    data: {
+      action: "cpFpSupportedList"
+    },
+    dataType: 'json',
+    error: function (request, status, error) {
+      handleAjaxError(request, status, error);
+    },
+    success: function (data) {
+      if (data.state != 'ok') {
+        $('#div_alert').showAlert({message: data.result, level: 'danger'});
+        return;
+      }
+      v_val = data.result;
+      v_data = JSON.parse(v_val);
+      
+      var v_html = '';
+      for (var i in v_data) {
+        var v_item = "#"+v_data[i]['human_name']+"#";
+        if (v_item == p_id) {
+          v_html += '<option value="'+v_item+'" selected>'+v_item+'</option>';
+        }
+        else {
+          v_html += '<option value="'+v_item+'">'+v_item+'</option>';
+        }
       }
     
       $('#cp_fp_device_list').html(v_html);
@@ -551,7 +604,32 @@ function cp_fp_update_list() {
 
 
 function cp_fp_device_change(event) {
-  //alert('Hello :'+event.target.value);
+  //alert('target :'+event.target.value);
+  //$('#cp_fp_device_selected').val(event.target.value);
+  
+  
+}
+
+function cp_fp_device_select(p_value) {
+  //alert('target :'+event.target.value);
+  $('#cp_fp_device_selected').val(p_value);
+  
+  $('#cp_fp_device_selected').show();
+  $('#cp_fp_device_list_open_span').show();
+
+  $('#cp_fp_device_list').hide();
+  $('#cp_fp_device_select_span').hide();
+ 
+}
+
+function cp_fp_device_cancel_select() {
+  
+  $('#cp_fp_device_selected').show();
+  $('#cp_fp_device_list_open_span').show();
+
+  $('#cp_fp_device_list').hide();
+  $('#cp_fp_device_select_span').hide();
+ 
 }
 
 

--- a/desktop/js/centralepilote.js
+++ b/desktop/js/centralepilote.js
@@ -60,6 +60,7 @@ function addCmdToTable(_cmd) {
 var refresh_timeout;
 
 function refreshDeviceList() {
+  //console.log('refresh device list');
   $('#device_list').load('index.php?v=d&plugin=centralepilote&modal=modal.device_list');
 }
 
@@ -596,6 +597,9 @@ function cp_fp_device_list_open(p_id='') {
       }
     
       $('#cp_fp_device_list').html(v_html);
+      
+      // ----- Copie de suite celui affiché dans la selection
+      $('#cp_fp_device_selected').val($('#cp_fp_device_list').val());
 
     }
   });
@@ -606,6 +610,8 @@ function cp_fp_device_list_open(p_id='') {
 function cp_fp_device_change(event) {
   //alert('target :'+event.target.value);
   //$('#cp_fp_device_selected').val(event.target.value);
+  
+  cp_fp_device_select(event.target.value);
   
   
 }
@@ -631,7 +637,6 @@ function cp_fp_device_cancel_select() {
   $('#cp_fp_device_select_span').hide();
  
 }
-
 
 
 

--- a/desktop/php/centralepilote.php
+++ b/desktop/php/centralepilote.php
@@ -17,6 +17,9 @@ $eqLogics = eqLogic::byType($plugin->getId());
   $(document).ready(function() {
     // do this stuff when the HTML is all ready
     refreshDeviceList();
+       
+    
+    
   });
 
 </script>
@@ -111,7 +114,7 @@ Bon mais c'est juste pour que ce soit joli à l'affichage ...
 			</span>
 		</div>
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fa fa-arrow-circle-left"></i></a></li>
+    <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay" onClick="refreshDeviceList();"><i class="fa fa-arrow-circle-left"></i></a></li>
     <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
     <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fa fa-list-alt"></i> {{Commandes}}</a></li>
   </ul>

--- a/desktop/php/centralepilote_radiateur.inc.php
+++ b/desktop/php/centralepilote_radiateur.inc.php
@@ -60,38 +60,21 @@
       </label>
     <div class="col-sm-7">
 
-      <select id="cp_fp_device_list" class="cp_attr_radiateur eqLogicAttr form-control" data-l1key="configuration" data-l2key="fp_device_id" onchange="cp_fp_device_change(event)">
-        
-<?php 
-  // ----- Remplacé par un call uniquement lors de l'affichage voir cp_fp_update_list()
-  /*
-  $v_device_info_list = centralepilote::cpDeviceSupportedList();  
-  
-  $v_plugin_list = plugin::listPlugin(true);
-  foreach ($v_plugin_list as $v_plugin) {
-  	$v_plugin_id = $v_plugin->getId();
-  	if (!isset($v_device_info_list[$v_plugin_id])) continue;
-        
-    $eqLogics = eqLogic::byType($v_plugin_id);
-    foreach ($eqLogics as $v_eq) {
-      $v_device_info = centralepilote::cpDeviceSupportedInfo($v_eq);
-      if ($v_device_info != null) {
-        $v_human_name = $v_eq->getHumanName();
-        //$v_name = (isset($v_device_info['name'])?' ('.$v_device_info['name'].')':'');
-        
-        //echo '<option value="#'.$v_human_name.'#">'.$v_human_name.$v_name.'</option>';
-        echo '<option value="#'.$v_human_name.'#">'.$v_human_name.'</option>';
-      }
-    }
-  }
-  */
-  
-?>
-
+      <textarea id="cp_fp_device_selected" class="cp_attr_radiateur eqLogicAttr form-control" data-l1key="configuration" data-l2key="fp_device_id" style="height : 33px;" placeholder="{{Référence équipement associé}}"></textarea>
+      <select id="cp_fp_device_list" class="cp_attr_radiateur  form-control" onchange="cp_fp_device_change(event)" style="display:none;">
+        <!-- Rempli par javascript -->
       </select>
+
 
     </div>
     <div class="col-sm-1">
+      <span id="cp_fp_device_list_open_span">
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_list_open( $('#cp_fp_device_selected').val() );"><i class="fas fa-sync"></i> {{Changer équipement}}</a>
+      </span>
+      <span id="cp_fp_device_select_span" style="display:none; white-space: nowrap;">
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_select( $('#cp_fp_device_list').val() );" ><i class="fas fa-check" ></i>&nbsp;{{Valider}}</a>
+      <a class="btn btn-default cursor  btn-sm" onClick="cp_fp_device_cancel_select( );"><i class="fas fa-ban" ></i>&nbsp;{{Annuler}}</a>
+      </span>
     </div>
   </div>
 

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -36,9 +36,11 @@ if (!isConnect()) {
             </div>
         </div>
         <div class="row form-group">
-            <label class="col-lg-4 control-label">{{Icônes des modes colorées}} : </label>
+            <label class="col-lg-4 control-label">{{Icônes colorées pour les modes}} : </label>
             <div class="col-lg-5">
-                <input type="checkbox" class="configKey form-control" data-l1key="mode_icon_color">
+                <input type="checkbox" class="configKey form-control" data-l1key="mode_icon_color"> {{Tableau de bord}}
+                <br>
+                <input type="checkbox" class="configKey form-control" data-l1key="mode_icon_color_mobile"> {{Mobile}}
             </div>
         </div>
         <div class="row form-group">

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -36,6 +36,12 @@ if (!isConnect()) {
             </div>
         </div>
         <div class="row form-group">
+            <label class="col-lg-4 control-label">{{Icônes des modes colorées}} : </label>
+            <div class="col-lg-5">
+                <input type="checkbox" class="configKey form-control" data-l1key="mode_icon_color">
+            </div>
+        </div>
+        <div class="row form-group">
             <label class="col-lg-4 control-label">{{Github Version}} : <?php echo CP_VERSION;?></label>
         </div>
 

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.7-beta",
+    "version": "1.8.8-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.7-dev",
+    "version": "1.8.7-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.6-beta",
+    "version": "1.8.7-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.6-dev",
+    "version": "1.8.6-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.8-beta",
+    "version": "1.8.9-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.8-dev",
+    "version": "1.8.8-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.5",
+    "version": "1.8.6-dev",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.9-beta",
+    "version": "1.8.9",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.4",
+    "version": "1.8.5",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -5,7 +5,7 @@
 	"licence" : "AGPL",
 	"author" : "Vincent",
 	"require" : "4.0",
-    "version": "1.8.9-dev",
+    "version": "1.8.9-beta",
 	"category" : "energy",
 	"hasDependency" : false,
     "maxDependancyInstallTime" : 10,

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -119,28 +119,28 @@ function centralepilote_update_v_1_8_5($v_from_version='') {
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_1');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_1'");
-      $v_eq->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_confort_1', $v_eq->getConfiguration('temperature_confort_1','18'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_2');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_2'");
-      $v_eq->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_confort_2', $v_eq->getConfiguration('temperature_confort_2','17'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_eco');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_eco'");
-      $v_eq->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_eco', $v_eq->getConfiguration('temperature_eco','15'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_horsgel');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_horsgel'");
-      $v_eq->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_horsgel', $v_eq->getConfiguration('temperature_horsgel','3'));
     }
 

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -112,35 +112,35 @@ function centralepilote_update_v_1_8_5($v_from_version='') {
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort'");
-      $v_eq->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_confort', $v_eq->getConfiguration('temperature_confort','19'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_1');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_1'");
-      $v_eq->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort-1', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_confort_1', $v_eq->getConfiguration('temperature_confort_1','18'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_2');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_2'");
-      $v_eq->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort-2', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_confort_2', $v_eq->getConfiguration('temperature_confort_2','17'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_eco');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_eco'");
-      $v_eq->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Eco', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_eco', $v_eq->getConfiguration('temperature_eco','15'));
     }
 
     $v_cmd = $v_eq->getCmd(null, 'temp_ref_horsgel');
     if (!is_object($v_cmd)) {
       centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_horsgel'");
-      $v_eq->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_HorsGel', 'type'=>'info', 'subtype'=>'numeric', 'isHistorized'=>0, 'isVisible'=>0]);
       $v_eq->checkAndUpdateCmd('temp_ref_horsgel', $v_eq->getConfiguration('temperature_horsgel','3'));
     }
 

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -85,11 +85,67 @@ function centralepilote_update() {
   if ($v_version < '1.4') centralepilote_update_v_1_4($v_version);
   if ($v_version < '1.5') centralepilote_update_v_1_5($v_version);
   if ($v_version < '1.6') centralepilote_update_v_1_6($v_version);
+  
+  if (version_compare($v_version, '1.8.5', '<')) centralepilote_update_v_1_8_5($v_version);
     
   // ----- Save current version
   config::save('version', CP_VERSION, 'centralepilote');
 
   log::add('centralepilote', 'info', "Finished update of plugin 'centralepilote' to ".CP_VERSION);  
+}
+
+function centralepilote_update_v_1_8_5($v_from_version='') {
+
+  log::add('centralepilote', 'info', "Update devices to version 1.8.5 of plugin 'centralepilote'");
+
+  // ----- Look for each centrale
+  $eqLogics = eqLogic::byType('centralepilote');
+  
+  foreach ($eqLogics as $v_eq) {
+    $v_flag_save = false;
+    
+    if (!$v_eq->cpIsType(array('centrale'))) {
+      continue;
+    }
+    
+    // ----- Look to add cmd
+    $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort');
+    if (!is_object($v_cmd)) {
+      centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort'");
+      $v_eq->cpCmdCreate('temp_ref_confort', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->checkAndUpdateCmd('temp_ref_confort', $v_eq->getConfiguration('temperature_confort','19'));
+    }
+
+    $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_1');
+    if (!is_object($v_cmd)) {
+      centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_1'");
+      $v_eq->cpCmdCreate('temp_ref_confort_1', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->checkAndUpdateCmd('temp_ref_confort_1', $v_eq->getConfiguration('temperature_confort_1','18'));
+    }
+
+    $v_cmd = $v_eq->getCmd(null, 'temp_ref_confort_2');
+    if (!is_object($v_cmd)) {
+      centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_confort_2'");
+      $v_eq->cpCmdCreate('temp_ref_confort_2', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->checkAndUpdateCmd('temp_ref_confort_2', $v_eq->getConfiguration('temperature_confort_2','17'));
+    }
+
+    $v_cmd = $v_eq->getCmd(null, 'temp_ref_eco');
+    if (!is_object($v_cmd)) {
+      centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_eco'");
+      $v_eq->cpCmdCreate('temp_ref_eco', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->checkAndUpdateCmd('temp_ref_eco', $v_eq->getConfiguration('temperature_eco','15'));
+    }
+
+    $v_cmd = $v_eq->getCmd(null, 'temp_ref_horsgel');
+    if (!is_object($v_cmd)) {
+      centralepilotelog::log('debug', "Centrale '".$v_eq->getName()."' : Add missing cmd 'temp_ref_horsgel'");
+      $v_eq->cpCmdCreate('temp_ref_horsgel', ['name'=>'Temp_Ref_Confort', 'type'=>'info', 'subtype'=>'string', 'isHistorized'=>0, 'isVisible'=>0]);
+      $v_eq->checkAndUpdateCmd('temp_ref_horsgel', $v_eq->getConfiguration('temperature_horsgel','3'));
+    }
+
+  }
+    
 }
 
 function centralepilote_update_v_1_6($v_from_version='') {


### PR DESCRIPTION
Nouveautés :

- Ajout de commandes de type 'info' pour récupérer par programmation les valeurs des températures de référence, configurées dans l'objet "Centrale fil-pilote"
- Ajout d'une configuration globale (mode_icon_color) permettant d'afficher les icônes des modes (confort, eco, etc) en couleur. Particulièrement interessant pour les modes confort-1 et confort-2 qui utilisent le même icône que confort.
- Ajouté la possibilité de selectionner l'affichage de la couleur des icones de mode pour le tableau de bord et/ou pour le mobile.

Bug corrections :

- Lorsqu'un radiateur utilisait un objet connecté natif fil-pilote, l'identifiant de celui-ci n'était pas afficher correctement lorsque l'on revenait sur la page de configuration. Le mode de selection des objets a été modifié pour corriger cela et aussi pour optimiser le code listant les objets compatibles.
- Lorsque l'on était dans la vue de configuration d'un objet le retour par la petite flèche de gauche ne déclenchait pas le réaffichage de la liste des objets. Cela est maintenant le cas.
- Ajout de l'affichage en couleur aussi pour le mode mobile